### PR TITLE
add test cases

### DIFF
--- a/saku/tests/sentence-tokenizer.rs
+++ b/saku/tests/sentence-tokenizer.rs
@@ -13,6 +13,85 @@ fn test_tokenize_short() {
     let actual = tokenizer.tokenize(document, false);
     assert_eq!(expected, actual);
 }
+#[test]
+fn test_tokenize_short_mismatch_parenthesis_char_format() {
+    let document = "どうもこんにちは。私の名前は山田です。(どーも。）で囲んでいます。";
+    let tokenizer = SentenceTokenizer::new(None, None);
+
+    let expected = vec![
+        "どうもこんにちは。",
+        "私の名前は山田です。",
+        "(どーも。",
+        "）で囲んでいます。",
+    ];
+    let actual = tokenizer.tokenize(document, false);
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_tokenize_short_mismatch_parenthesis_char_format_with_custom_pattern() {
+    let document = "「どうもこんにちは。私の名前は山田です。」(どーも。）で囲んでいます。";
+    const PAT :[[char; 2]; 1]=[['(', '）']];
+    let tokenizer = SentenceTokenizer::new(None, Some(&PAT));
+
+    let expected = vec![
+        "「どうもこんにちは。",
+        "私の名前は山田です。",
+        "」(どーも。）で囲んでいます。",
+    ];
+    let actual = tokenizer.tokenize(document, false);
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn short_nested_parenthesis() {
+    let document = "「どうもこんにちは。私の名前は山田です。(どーも。)で囲んでいます。」";
+    let tokenizer = SentenceTokenizer::new(None, None);
+
+    let expected = vec!["「どうもこんにちは。私の名前は山田です。(どーも。)で囲んでいます。」"];
+    let actual = tokenizer.tokenize(document, false);
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn short_missing_right_parenthesis() {
+    let document = "(どうもこんにちは。「どーも。で囲んでいます。";
+    let tokenizer = SentenceTokenizer::new(None, None);
+
+    let expected = vec!["(どうもこんにちは。", "「どーも。で囲んでいます。"];
+    let actual = tokenizer.tokenize(document, false);
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn short_missing_left_parenthesis() {
+    let document = "どうもこんにちは。)どーも。」で囲んでいます。";
+    let tokenizer = SentenceTokenizer::new(None, None);
+
+    let expected = vec!["どうもこんにちは。", ")どーも。", "」で囲んでいます。"];
+    let actual = tokenizer.tokenize(document, false);
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn short_mismatched_parenthesis() {
+    let document = "「どーも。)で囲んでいます。";
+    let tokenizer = SentenceTokenizer::new(None, None);
+
+    let expected = vec!["「どーも。)で囲んでいます。"];
+    let actual = tokenizer.tokenize(document, false);
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn short_mismatched_nested_parenthesis() {
+    let document = "「どーも。)で囲んでいます。(どーも。」で囲んでいます。";
+    let tokenizer = SentenceTokenizer::new(None, None);
+
+    let expected = vec!["「どーも。)で囲んでいます。(どーも。」で囲んでいます。"];
+    let actual = tokenizer.tokenize(document, false);
+    assert_eq!(expected, actual);
+}
 
 #[test]
 fn test_tokenize_medium() {


### PR DESCRIPTION
Test cases do not cover some exceptions such as missing parenthesis or
mismatched parenthesis.
This commit just adds small test cases for those cases.

I think patterns are not always one-to-one pair.(e.g.  Considering half-char and full-char, users sometimes want '(' and '（' to be matched by ')' and '）' .) What do you think of  signature like `(Set<Char>,Set<Char>)`?

I also think it would be better if users can choose whether they override default patterns or append patterns.  Current implementation always overrides default patterns.
For example, we can define custom patterns parameter as ADT.

```scala

enum Patterns {
  case Override(pat)
  case Add(pat)
}

val patterns = patterns match
  case Override(pat) => pat
  case Add(pat) => DEFAULT_PATTERNS ++ pat

```